### PR TITLE
Show account linked with Tide message on landing page

### DIFF
--- a/app/components/LoadingPage.jsx
+++ b/app/components/LoadingPage.jsx
@@ -136,17 +136,17 @@ export default function LoadingPage({ isInitializing, setIsInitializing }) {
     }
 
     // Update the Custom Domain URL for the Tide Enclave to work
-    const updateCustomDomainURL = async () => {
-        const response = await fetch(`/api/updateCustomDomainURL`, {
-            method: "GET",
+    const updateCustomDomainURL = async (params = {}) => {
+        const qs = new URLSearchParams(params).toString();
+        const url = `/api/updateCustomDomainURL${qs ? '?' + qs : ''}`;
 
-        })
-
+        const response = await fetch(url, { method: 'GET' });
         if (!response.ok) {
-            const errorResponse = await response.json();
-            throw new Error(errorResponse.error || "Failed to update the Custom Domain URL for the Tide IDP.");
+            const err = await response.json();
+            throw new Error(err.error || 'Failed to update domain URL');
         }
-    }
+        return response;
+    };
 
     // Upload background and logo image to tidecloak
     const uploadImages = async () => {
@@ -199,6 +199,7 @@ export default function LoadingPage({ isInitializing, setIsInitializing }) {
             await updateCustomDomainURL();
             await uploadImages();
             await signSettings();
+            await updateCustomDomainURL({linkedTide: true});
             await getAdapter();
 
             setIsInitializing(false);


### PR DESCRIPTION
- added query param to custom domain url temporarily after signing settings on initializer
-  remove this query param to custom domain after showing the message

TEMP solution, will do proper query param on tidecloak later on